### PR TITLE
Add system status feature

### DIFF
--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -110,8 +110,11 @@ export default function LoginPage() {
             </button>
           </div>
         </form>
-         <p className="text-center text-xs text-text-muted">
-          Demo credentials: user@example.com / password123
+        <p className="text-center text-xs text-text-muted">
+         Demo credentials: user@example.com / password123
+        </p>
+        <p className="text-center text-xs mt-2">
+          <a href="/status" className="text-primary hover:underline">System Status</a>
         </p>
       </div>
     </div>

--- a/src/app/room-entry/page.tsx
+++ b/src/app/room-entry/page.tsx
@@ -84,8 +84,11 @@ export default function RoomEntryPage() {
         </form>
       </div>
        <p className="mt-8 text-sm text-text-muted">
-          Enter any Room ID. If it doesn't exist, a new room will be created.
-        </p>
+         Enter any Room ID. If it doesn't exist, a new room will be created.
+       </p>
+       <p className="mt-2 text-sm">
+          <a href="/status" className="text-primary hover:underline">Check System Status</a>
+       </p>
     </div>
   );
 }

--- a/src/app/status/page.tsx
+++ b/src/app/status/page.tsx
@@ -1,0 +1,44 @@
+"use client";
+import React, { useEffect, useState } from 'react';
+
+interface StatusResponse {
+  running: boolean;
+  database: boolean;
+  error?: string;
+}
+
+export default function StatusPage() {
+  const [status, setStatus] = useState<StatusResponse | null>(null);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    fetch('/api/status')
+      .then(async (res) => {
+        const data = await res.json();
+        setStatus(data);
+      })
+      .catch((err) => {
+        setStatus({ running: true, database: false, error: err.message });
+      })
+      .finally(() => setLoading(false));
+  }, []);
+
+  if (loading) {
+    return (
+      <div className="flex items-center justify-center min-h-screen bg-background">
+        <p className="text-text text-xl">Checking system status...</p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex flex-col items-center justify-center min-h-screen bg-background space-y-4 p-4">
+      <h1 className="text-3xl font-bold text-primary-text">System Status</h1>
+      <div className="bg-card border border-border rounded-lg p-6 w-full max-w-md space-y-2">
+        <p className="text-text">Application: <span className="font-semibold">{status?.running ? 'Running' : 'Stopped'}</span></p>
+        <p className="text-text">Database connection: <span className="font-semibold">{status?.database ? 'OK' : 'Failed'}</span></p>
+        {status?.error && <p className="text-danger text-sm">Error: {status.error}</p>}
+      </div>
+    </div>
+  );
+}

--- a/src/pages/api/status.ts
+++ b/src/pages/api/status.ts
@@ -1,0 +1,16 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
+import { supabase } from '@/lib/supabaseClient';
+
+export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+  if (req.method !== 'GET') {
+    return res.status(405).json({ message: 'Method Not Allowed' });
+  }
+
+  try {
+    const { error } = await supabase.from('app_logs').select('id').limit(1);
+    if (error) throw error;
+    return res.status(200).json({ running: true, database: true });
+  } catch (err: any) {
+    return res.status(500).json({ running: true, database: false, error: err.message });
+  }
+}


### PR DESCRIPTION
## Summary
- add `/api/status` endpoint for system and DB status
- create a new `/status` page showing application and DB health
- link to the status page from login and room entry pages

## Testing
- `npm install`
- `npm run lint` *(fails: prompts for ESLint configuration)*

------
https://chatgpt.com/codex/tasks/task_e_6841a1295ea4832aa1c23a57125ee69f