### PR TITLE
Add security headers and HTTPS enforcement

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -1,0 +1,52 @@
+export default {
+  async headers() {
+    const securityHeaders = [
+      {
+        key: 'Strict-Transport-Security',
+        value: 'max-age=63072000; includeSubDomains; preload'
+      },
+      {
+        key: 'X-Content-Type-Options',
+        value: 'nosniff'
+      },
+      {
+        key: 'X-Frame-Options',
+        value: 'DENY'
+      },
+      {
+        key: 'Referrer-Policy',
+        value: 'no-referrer-when-downgrade'
+      },
+      {
+        key: 'Content-Security-Policy',
+        value: "default-src 'self'; script-src 'self'; connect-src 'self'; img-src 'self' data:; style-src 'self' 'unsafe-inline';"
+      }
+    ];
+
+    const corsHeaders = [
+      {
+        key: 'Access-Control-Allow-Origin',
+        value: '*'
+      },
+      {
+        key: 'Access-Control-Allow-Methods',
+        value: 'GET,POST,PUT,DELETE,OPTIONS'
+      },
+      {
+        key: 'Access-Control-Allow-Headers',
+        value: 'Content-Type, Authorization'
+      }
+    ];
+
+    return [
+      {
+        source: '/api/:path*',
+        headers: [...securityHeaders, ...corsHeaders]
+      },
+      {
+        source: '/:path*',
+        headers: securityHeaders
+      }
+    ];
+  }
+};

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -35,6 +35,15 @@ async function verifyToken(token: string) {
 }
 
 export async function middleware(request: NextRequest) {
+  // Enforce HTTPS in production deployments
+  if (
+    process.env.NODE_ENV === "production" &&
+    request.headers.get("x-forwarded-proto") !== "https"
+  ) {
+    const url = request.nextUrl
+    url.protocol = "https:"
+    return NextResponse.redirect(url, 308)
+  }
   const { pathname } = request.nextUrl;
   const response = NextResponse.next();
 


### PR DESCRIPTION
## Summary
- add security and CORS headers in `next.config.mjs`
- enforce HTTPS via middleware in production

## Testing
- `npm install`
- `npm run lint` *(fails: How would you like to configure ESLint?)*

------
https://chatgpt.com/codex/tasks/task_e_68420985c5d8832a81a8503c77cddf73