### PR TITLE
Use env for TURN server config

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,16 @@
+# Example environment variables for NextRTC Video Call application
+
+# JWT secret key used for signing tokens
+JWT_SECRET="your-super-secure-and-long-jwt-secret-key-at-least-32-characters"
+
+# Base URL of the application
+NEXT_PUBLIC_APP_URL="http://localhost:3000"
+
+# Path for the Socket.IO server
+NEXT_PUBLIC_SOCKET_PATH="/api/socketio"
+
+# TURN server configuration
+# Comma-separated list of TURN URLs
+TURN_URLS="turns:secure.example.com:5349"
+TURN_USERNAME="user"
+TURN_CREDENTIAL="secret"

--- a/src/pages/api/webrtc-config.ts
+++ b/src/pages/api/webrtc-config.ts
@@ -4,12 +4,21 @@ export default function handler(req: NextApiRequest, res: NextApiResponse) {
   if (req.method !== 'GET') {
     return res.status(405).json({ message: 'Method Not Allowed' });
   }
+
+  const turnUrls = (process.env.TURN_URLS || 'turns:secure.example.com:5349')
+    .split(',')
+    .map((u) => u.trim())
+    .filter(Boolean);
+
+  const turnUsername = process.env.TURN_USERNAME || 'user';
+  const turnCredential = process.env.TURN_CREDENTIAL || 'secret';
+
   return res.status(200).json({
     iceServers: [
       {
-        urls: ['turns:secure.example.com:5349'],
-        username: 'user',
-        credential: 'secret',
+        urls: turnUrls,
+        username: turnUsername,
+        credential: turnCredential,
       },
     ],
     iceTransportPolicy: 'relay',


### PR DESCRIPTION
## Summary
- load TURN server config in webrtc-config API route from `TURN_URLS`, `TURN_USERNAME`, and `TURN_CREDENTIAL`
- provide example values in new `.env.example`

## Testing
- `npm run lint` *(fails: prompts for ESLint setup)*

------
https://chatgpt.com/codex/tasks/task_e_684209851ce0832a89d73d8c480022b8