### PR TITLE
Write uploads to public directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -96,4 +96,6 @@ uploads/
 logs/
 !uploads/.gitkeep
 !logs/.gitkeep
+public/uploads/
+!public/uploads/.gitkeep
 

--- a/src/pages/api/upload.ts
+++ b/src/pages/api/upload.ts
@@ -34,7 +34,7 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
     if (!allowed.includes(file.mimetype || '')) {
       return res.status(400).json({ message: 'Invalid file type' });
     }
-    const uploadDir = path.join(process.cwd(), 'uploads');
+    const uploadDir = path.join(process.cwd(), 'public', 'uploads');
     if (!fs.existsSync(uploadDir)) fs.mkdirSync(uploadDir, { recursive: true });
     const filename = Date.now() + '_' + file.originalFilename;
     const dest = path.join(uploadDir, filename);


### PR DESCRIPTION
## Summary
- keep public uploads directory
- store uploaded files under `public/uploads`

## Testing
- `npm run lint` *(fails: prompts for ESLint configuration)*

------
https://chatgpt.com/codex/tasks/task_e_684209847abc832aa8552956cbbc4f11