### PR TITLE
Add sessions API

### DIFF
--- a/src/pages/api/sessions/index.ts
+++ b/src/pages/api/sessions/index.ts
@@ -1,0 +1,19 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
+import { verifyToken, ACCESS_TOKEN_NAME } from '@/lib/authUtils';
+import { getAllSessions } from '@/lib/sessionManager';
+
+export default function handler(req: NextApiRequest, res: NextApiResponse) {
+  if (req.method !== 'GET') {
+    return res.status(405).json({ message: 'Method Not Allowed' });
+  }
+
+  const token = req.cookies[ACCESS_TOKEN_NAME] || '';
+  const user = token ? verifyToken(token) : null;
+
+  if (!user) {
+    return res.status(401).json({ message: 'Unauthorized' });
+  }
+
+  const sessions = getAllSessions();
+  return res.status(200).json(sessions);
+}


### PR DESCRIPTION
## Summary
- add `src/pages/api/sessions/index.ts` for listing active sessions after JWT auth

## Testing
- `npm install`
- `npm run lint` *(fails: prompts for ESLint configuration)*

------
https://chatgpt.com/codex/tasks/task_e_6842b219d0ec832a969a0a40f2c7e374